### PR TITLE
fixed bug with displaying tree with depth greater than 1 

### DIFF
--- a/js/ui-tree.js
+++ b/js/ui-tree.js
@@ -22,6 +22,17 @@
 			this.parent = ko.observable(parent);
 			/*this.id = ko.observable(data.id)*/
 			this.contextMenu = viewModel.contextMenu;
+			
+			this.level = ko.dependentObservable(function () {
+				try {
+					var pname = this.parent().name(),
+						plevel = this.parent().level();
+					return this.parent().level() + 1; 
+				} catch (err) { 
+					return 0; 
+				}
+			}, this);
+			
 			// assign the childrens parent
 			var self = this, vm = this.viewModel, openSelfAndParents, 
 				childMapping =  {
@@ -34,16 +45,6 @@
 			
 			// map incoming data
 			ko.mapping.fromJS(data, childMapping, this);
-			
-			this.level = ko.dependentObservable(function () {
-				try {
-					var pname = this.parent().name(),
-						plevel = this.parent().level();
-					return this.parent().level() + 1; 
-				} catch (err) { 
-					return 0; 
-				}
-			}, this);
 			
 			// defaults
 			this.cssClass = ko.observable(data.cssClass || 'folder');


### PR DESCRIPTION
Been using your Tree UI component and noticed that it loses the indent if the node has children.

http://jsfiddle.net/pabloski/K9S36/10/

Coz the call to set child nodes is recursive their parents level wasn't set before their children attempted to set theirs. I've just set the level before setting the children.

http://jsfiddle.net/pabloski/K9S36/11/

p.s. loving your work with these components.
