### PR TITLE
Checks during node move

### DIFF
--- a/js/ui-tree.js
+++ b/js/ui-tree.js
@@ -229,6 +229,17 @@
 			this.move = function (node) {
 				var that = this;
 				viewModel.handlers.moveNode(node, this, function () {
+					
+					// check that 'that' is not a descendent of 'node'
+					// otherwise abort
+					var ancestor = that
+					while ( ancestor && ancestor.parent )
+					{
+						ancestor = ancestor.parent()
+						if ( ancestor == node )
+							return
+					}
+					
 					node.parent().children.remove(node);
 					node.parent(that);
 					that.children.push(node);


### PR DESCRIPTION
Without this check, when an ancestor is dragged onto a descendant, the whole tree vanishes.
